### PR TITLE
faster ascii check

### DIFF
--- a/include/simdasciicheck.h
+++ b/include/simdasciicheck.h
@@ -8,11 +8,9 @@
 static bool validate_ascii_fast(const char *src, size_t len) {
   size_t i = 0;
   __m128i has_error = _mm_setzero_si128();
-  __m128i zero = _mm_setzero_si128();
   for (; i + 15 < len; i += 16) {
     __m128i current_bytes = _mm_loadu_si128((const __m128i *)(src + i));
-    has_error =
-      _mm_or_si128(has_error, _mm_cmpgt_epi8(zero,current_bytes));
+    has_error = _mm_or_si128(has_error, current_bytes);
   }
 
   // last part
@@ -21,9 +19,11 @@ static bool validate_ascii_fast(const char *src, size_t len) {
     memset(buffer, 0, 16);
     memcpy(buffer, src + i, len - i);
     __m128i current_bytes = _mm_loadu_si128((const __m128i *)(buffer));
-    has_error =
-      _mm_or_si128(has_error, _mm_cmpgt_epi8(zero,current_bytes));
+    has_error = _mm_or_si128(has_error, current_bytes);
   }
+
+  __m128i signbitmask = _mm_set1_epi8(0b10000000);
+  has_error = _mm_and_si128(has_error, signbitmask);
 
   return _mm_testz_si128(has_error, has_error);
 }

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 #include "simdutf8check.h"
-
+#include "simdasciicheck.h"
 
 
 void test() {
@@ -30,6 +30,11 @@ void test() {
     size_t len = strlen(badsequences[i]);
     assert(!validate_utf8_fast(badsequences[i], len));
   }
+
+  char ascii[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 0};
+  char notascii[] = {128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 238, 255, 0};
+  assert(validate_ascii_fast(ascii, strlen(ascii)));
+  assert(!validate_ascii_fast(notascii, strlen(notascii)));
 }
 
 int main() {


### PR DESCRIPTION
with 4096, 50k iterations, Skylake-EP

```
# before:
validate_ascii_fast(data, N)   :  0.102 cycles per operation (best)    0.118 cycles per operation (avg)
# after:
validate_ascii_fast(data, N)   :  0.086 cycles per operation (best)    0.101 cycles per operation (avg) 
```

I think this is correct... unless a zero byte is considered not valid ASCII.

---

Also, rdtsc counts reference cycles, not core clock cycles, so it's not really a correct benchmark. For comparing two implementations it's okayish (assuming they don't affect the core clock speed differently).