### PR TITLE
cleaner fast ascii check

### DIFF
--- a/include/simdasciicheck.h
+++ b/include/simdasciicheck.h
@@ -1,10 +1,12 @@
-
 #ifndef SIMDASCIICHECK_H
 #define SIMDASCIICHECK_H
-#include <stddef.h>
-#include <stdint.h>
-#include <x86intrin.h>
 
+#include <stddef.h> // size_t
+#include <stdbool.h> // c99 bool
+#include <emmintrin.h> // SSE2
+
+// The function returns true (1) if all chars passed in src are 
+// 7-bit values (0x00..0x7F). Otherwise, it returns false (0).
 static bool validate_ascii_fast(const char *src, size_t len) {
   size_t i = 0;
   __m128i has_error = _mm_setzero_si128();
@@ -12,20 +14,15 @@ static bool validate_ascii_fast(const char *src, size_t len) {
     __m128i current_bytes = _mm_loadu_si128((const __m128i *)(src + i));
     has_error = _mm_or_si128(has_error, current_bytes);
   }
+  int error_mask = _mm_movemask_epi8(has_error);
 
-  // last part
-  if (i < len) {
-    char buffer[16];
-    memset(buffer, 0, 16);
-    memcpy(buffer, src + i, len - i);
-    __m128i current_bytes = _mm_loadu_si128((const __m128i *)(buffer));
-    has_error = _mm_or_si128(has_error, current_bytes);
+  char tail_has_error = 0;
+  for (; i < len; i++) {
+    tail_has_error |= src[i];
   }
+  error_mask |= (tail_has_error & 0x80);
 
-  __m128i signbitmask = _mm_set1_epi8(0b10000000);
-  has_error = _mm_and_si128(has_error, signbitmask);
-
-  return _mm_testz_si128(has_error, has_error);
+  return !error_mask;
 }
 
 #endif


### PR DESCRIPTION
binary literal prefix `0b` is C++14 but (afaik) is not part of the C standard.

the vectorized tail loop is probably slow:
broadcast a new literal
memset
memcpy followed by loadu128 (stall?)
ptest has high latency which is not hidden.

Instead, lets just use a scalar check.