### PR TITLE
Improvements to CheckContinuations 

### DIFF
--- a/tests/unit.c
+++ b/tests/unit.c
@@ -11,7 +11,7 @@
 
 
 void test() {
-  char *goodsequences[] = {"a", "\xc3\xb1", "\xe2\x82\xa1", "\xf0\x90\x8c\xbc"};
+  char *goodsequences[] = {"a", "\xc3\xb1", "\xe2\x82\xa1", "\xf0\x90\x8c\xbc", "안녕하세요, 세상"};
   char *badsequences[] = {"\xc3\x28",         // 0
                           "\xa0\xa1",         // 1
                           "\xe2\x28\xa1",     // 2
@@ -22,7 +22,7 @@ void test() {
                           "\xc0\x9f",         // 7
                           "\xf5\xff\xff\xff", // 8
                           "\xed\xa0\x81"};    // 9
-  for (size_t i = 0; i < 4; i++) {
+  for (size_t i = 0; i < 5; i++) {
     size_t len = strlen(goodsequences[i]);
     assert(validate_utf8_fast(goodsequences[i], len));
   }
@@ -35,6 +35,23 @@ void test() {
   char notascii[] = {128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 238, 255, 0};
   assert(validate_ascii_fast(ascii, strlen(ascii)));
   assert(!validate_ascii_fast(notascii, strlen(notascii)));
+
+  __m128i cont = _mm_setr_epi8(4,0,0,0,3,0,0,2,0,1,2,0,3,0,0,1);
+  __m128i has_error = _mm_setzero_si128();
+  checkContinuation( cont, _mm_set1_epi8(1), &has_error);
+  assert(_mm_test_all_zeros(has_error, has_error));
+
+  // overlap
+  cont = _mm_setr_epi8(4,0,1,0,3,0,0,2,0,1,2,0,3,0,0,1);
+  has_error = _mm_setzero_si128();
+  checkContinuation( cont, _mm_set1_epi8(1), &has_error);
+  assert(!_mm_test_all_zeros(has_error, has_error));
+
+  // underlap
+  cont = _mm_setr_epi8(4,0,0,0,0,0,0,2,0,1,2,0,3,0,0,1);
+  has_error = _mm_setzero_si128();
+  checkContinuation( cont, _mm_set1_epi8(1), &has_error);
+  assert(!_mm_test_all_zeros(has_error, has_error));
 }
 
 int main() {


### PR DESCRIPTION
There are a few improvements:

Counts are carried right by doubling twice instead of shifting thrice.  This entails assigning each initial byte its length (including ascii => 1), and shifting, decrementing (saturated), and summing back into the original, for shifts 1 and 2.  This expands sequences from 1 to 2, then from 2 to 4, with the same saturation to 0 for shorter lengths. 

Boolean algebra is improved for underlap and overlap by observing that overlap makes a nonzero (ie initial) element in the original vector larger, and underlap leaves a zero instead of increasing it.  This reduces has_error to (final > original) == (original > 0).  

This seems about .3 cycles faster on skylake and passes unit.