### PR TITLE
checkContinuation should save sums in counts

### DIFF
--- a/tests/unit.c
+++ b/tests/unit.c
@@ -53,20 +53,29 @@ void test() {
 
   __m128i cont = _mm_setr_epi8(4,0,0,0,3,0,0,2,0,1,2,0,3,0,0,1);
   __m128i has_error = _mm_setzero_si128();
-  checkContinuation( cont, _mm_set1_epi8(1), &has_error);
+  checkContinuation( &cont, _mm_set1_epi8(1), &has_error);
   assert(_mm_test_all_zeros(has_error, has_error));
+  assert(_mm_test_all_ones(_mm_cmpeq_epi8(cont, _mm_setr_epi8(4,3,2,1,3,2,1,2,1,1,2,1,3,2,1,1))));
 
   // overlap
   cont = _mm_setr_epi8(4,0,1,0,3,0,0,2,0,1,2,0,3,0,0,1);
   has_error = _mm_setzero_si128();
-  checkContinuation( cont, _mm_set1_epi8(1), &has_error);
+  checkContinuation( &cont, _mm_set1_epi8(1), &has_error);
   assert(!_mm_test_all_zeros(has_error, has_error));
 
   // underlap
   cont = _mm_setr_epi8(4,0,0,0,0,0,0,2,0,1,2,0,3,0,0,1);
   has_error = _mm_setzero_si128();
-  checkContinuation( cont, _mm_set1_epi8(1), &has_error);
+  checkContinuation( &cont, _mm_set1_epi8(1), &has_error);
   assert(!_mm_test_all_zeros(has_error, has_error));
+
+    // register crossing
+  cont = _mm_setr_epi8(0,2,0,3,0,0,2,0,1,2,0,3,0,0,1,1);
+  __m128i prev = _mm_setr_epi8(3,2,1,3,2,1,2,1,1,2,1,3,2,4,3,2);
+  has_error = _mm_setzero_si128();
+  checkContinuation( &cont, prev, &has_error);
+  assert(_mm_test_all_zeros(has_error, has_error));
+
 }
 
 int main() {


### PR DESCRIPTION
We're using the previous counts instead of the previous shift/subtracted (sum) vector, so it carries zeros across for, eg a vector ending in 4,0,0.  The sum vector from CheckContinuations should be saved in counts (ie it should be passed by reference and updated).  