### PR TITLE
Document that this software may be used in GPL version 2 software

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,6 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+NOTE: This software may be used as part of software released under the
+GNU General Public License (GPL) version 2.


### PR DESCRIPTION
Record in the license that this software may be used
in GPL version 2 software (such as the Linux kernel), as stated in
https://github.com/lemire/fastvalidate-utf-8/issues/16 .
For posterity, here's the conversation:

@david-a-wheeler:
Some projects are licensed using only the GPL 2.0, including the Linux
kernel and git. Many people, including the free software Foundation,
has stated that the Apache 2 license is not compatible with the GPL
version 2. Would you be willing to let the software also be used in GPL
version 2 software? Thanks.

@lemire:
Yes, that is fine. The incompatibility is, as you know, a technical matter.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>